### PR TITLE
Preserve key order

### DIFF
--- a/dict_zip/__init__.py
+++ b/dict_zip/__init__.py
@@ -2,21 +2,34 @@ import functools
 
 
 def dict_zip(*dictionaries):
-    common_keys = functools.reduce(lambda x, y: x | y,
-                                   (set(d.keys()) for d in dictionaries),
-                                   set())
-    return {
-        key: tuple(d[key] for d in dictionaries)
-        for key in common_keys
-        if all(key in d for d in dictionaries)
-    }
+    common_keys = functools.reduce(
+        lambda x, y: x & y, (set(d.keys()) for d in dictionaries)
+    )
+    return_dic = {}
+    for dic in dictionaries:
+        for key, val in dic.items():
+            if key in common_keys:
+                return_dic.setdefault(key, []).append(val)
+
+    return {key: tuple(val) for key, val in return_dic.items()}
 
 
 def dict_zip_longest(*dictionaries, fillvalue=None):
-    common_keys = functools.reduce(lambda x, y: x | y,
-                                   (set(d.keys()) for d in dictionaries),
-                                   set())
-    return {
-        key: tuple(d.get(key, fillvalue) for d in dictionaries)
-        for key in common_keys
-    }
+    all_keys = __all_keys(d.keys() for d in dictionaries)
+    return_dic = {key: tuple() for key in all_keys}
+
+    for dic in dictionaries:
+        for key in all_keys:
+            return_dic[key] += (dic.get(key, fillvalue),)
+
+    return return_dic
+
+
+def __all_keys(iterables):
+    keys = []
+    for iterable in iterables:
+        for key in iterable:
+            if key in keys:
+                continue
+            keys.append(key)
+    return keys

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,20 +4,43 @@ from dict_zip import dict_zip, dict_zip_longest
 
 
 class TestDictZip(unittest.TestCase):
-
     def test_basis(self) -> None:
-        d1 = {'a': 1, 'b': 2, 'c': 3}
-        d2 = {'a': 4, 'b': 5}
+        d1 = {"a": 1, "b": 2, "c": 3}
+        d2 = {"a": 4, "b": 5}
 
-        self.assertEqual(dict_zip(d1, d2),
-                         {'a': (1, 4), 'b': (2, 5)})
+        self.assertEqual(dict_zip(d1, d2), {"a": (1, 4), "b": (2, 5)})
 
-        self.assertEqual(dict_zip_longest(d1, d2),
-                         {'a': (1, 4), 'b': (2, 5), 'c': (3, None)})
+        self.assertEqual(
+            dict_zip_longest(d1, d2),
+            {"a": (1, 4), "b": (2, 5), "c": (3, None)}
+        )
 
     def test_fill_value(self) -> None:
-        d1 = {'a': 1, 'b': 2, 'c': 3}
-        d2 = {'a': 4, 'b': 5}
+        d1 = {"a": 1, "b": 2, "c": 3}
+        d2 = {"a": 4, "b": 5}
 
-        self.assertEqual(dict_zip_longest(d1, d2, fillvalue=10),
-                         {'a': (1, 4), 'b': (2, 5), 'c': (3, 10)})
+        self.assertEqual(
+            dict_zip_longest(d1, d2, fillvalue=10),
+            {"a": (1, 4), "b": (2, 5), "c": (3, 10)},
+        )
+
+    def test_key_order(self) -> None:
+        d1 = {"a": 1, "b": 2}
+        d2 = {"b": 4, "c": 2, "a": 5}
+        self.assertEqual(
+            list(dict_zip(d1, d2).keys()),
+            ["a", "b"],
+        )
+        self.assertEqual(
+            list(dict_zip_longest(d1, d2).keys()),
+            ["a", "b", "c"],
+        )
+
+        self.assertEqual(
+            list(dict_zip(d2, d1).keys()),
+            ["b", "a"],
+        )
+        self.assertEqual(
+            list(dict_zip_longest(d2, d1).keys()),
+            ["b", "c", "a"],
+        )


### PR DESCRIPTION
From Python 3.7, dict became order preserving.
dict_zip and dict_zip_longest should prefer this feature.
