### PR TITLE
Don't need to specify both of pull_request and push

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -2,7 +2,7 @@ name: Packaging
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
   release:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]


### PR DESCRIPTION
- pull_request (synchronize) includes in case of commits pushed to the branch
