### PR TITLE
Set version-scheme to only-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ package-dir = { "dict_zip" = "dict_zip" }
 
 [tool.setuptools_scm]
 write_to = "dict_zip/_version.py"
+version_scheme = "only-version"
 
 [tool.poe.tasks]
 test = "pytest"


### PR DESCRIPTION
The version is created when the package is released.
So suffixes such as .devN or .postN are not used.
