### PR TITLE
Implement: map_keys, map_values, map_items, tuple_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ It fills with fillvalue (default: `None`) when argument dict doesn't have match 
 {'a': (1, 3), 'b': (2, 4), 'c': (4, None)}
 ```
 
+## map_keys, map_values, map_items
+
+`map_keys`, `map_values`, and `map_items` are used to map keys, values, and items of dict.
+
+```python
+>>> from dict_zip import map_keys
+>>> map_keys({'a': 1, 'b': 2}, str.upper)
+{'A': 1, 'B': 2}
+>>> from dict_zip import map_values
+>>> map_values({'a': 1, 'b': 2}, str)
+{'a': '1', 'b': '2'}
+>>> from dict_zip import map_items
+>>> map_items({'a': 1, 'b': 2}, str.upper, str)
+{'A': '1', 'B': '2'}
+```
+
+## tuple_keys
+
+`tuple_keys` is used to convert dict keys to tuple.
+
+```python
+>>> from dict_zip import tuple_keys
+>>> tuple_keys({'a': 1, 'b': 2})
+{('a',): 1, ('b',): 2}
+```
+
 # Type hints
 
 dict_zip supports for type hints.

--- a/dict_zip/__init__.py
+++ b/dict_zip/__init__.py
@@ -17,6 +17,22 @@ Example:
 from ._version import __version__
 from .dict_zip import dict_zip
 from .dict_zip_longest import dict_zip_longest
+from .dict_map import (
+    map_keys,
+    map_values,
+    map_items,
+)
+from .tuple_keys import tuple_keys
 
 
-__all__ = ["dict_zip", "dict_zip_longest", "__version__"]
+__all__ = [
+    "dict_zip",
+    "dict_zip_longest",
+    "map_keys",
+    "map_values",
+    "map_items",
+    "map_keys_first",
+    "map_keys_last",
+    "tuple_keys",
+    "__version__",
+]

--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+from typing import TypeVar, Callable
+
+K = TypeVar("K")
+V = TypeVar("V")
+U = TypeVar("U")
+T = TypeVar("T")
+
+
+def map_keys(dic: dict[K, V], func: Callable[[K], U]) -> dict[U, V]:
+    """Apply a function to the keys of a dictionary.
+    Args:
+        dic: The dictionary to map.
+        func: The function to apply to the keys.
+    Returns:
+        A new dictionary with the same values but with the keys transformed by the function.
+    Example:
+        >>> from dict_zip import map_keys
+        >>> map_keys({'a': 1, 'b': 2}, str.upper)
+        {'A': 1, 'B': 2}
+        >>> map_keys({'a': 1, 'b': 2}, lambda x: x + '!')
+        {'a!': 1, 'b!': 2}
+        >>> map_keys({('a', 'b'): 1, ('c', 'd'): 2}, lambda x: ''.join(x))
+        {'ab': 1, 'cd': 2}
+    """
+    return map_items(dic, func, lambda v: v)
+
+
+def map_values(dic: dict[K, V], func: Callable[[V], U]) -> dict[K, U]:
+    """Apply a function to the values of a dictionary.
+    Args:
+        dic: The dictionary to map.
+        func: The function to apply to the values.
+    Returns:
+        A new dictionary with the same keys but with the values transformed by the function.
+    Example:
+        >>> from dict_zip import map_values
+        >>> map_values({'a': 1, 'b': 2}, str)
+        {'a': '1', 'b': '2'}
+        >>> map_values({'a': 1, 'b': 2}, lambda x: x + 1)
+        {'a': 2, 'b': 3}
+        >>> map_values({('a', 'b'): 1, ('c', 'd'): 2}, lambda x: x * 2)
+        {('a', 'b'): 2, ('c', 'd'): 4}
+    """
+    return map_items(dic, lambda k: k, func)
+
+
+def map_items(
+    dic: dict[K, V],
+    key_func: Callable[[K], U],
+    value_func: Callable[[V], T],
+) -> dict[U, T]:
+    """Apply a function to the keys and values of a dictionary.
+    Args:
+        dic: The dictionary to map.
+        key_func: The function to apply to the keys.
+        value_func: The function to apply to the values.
+    Returns:
+        A new dictionary with the keys and values transformed by the functions.
+    Example:
+        >>> from dict_zip import map_items
+        >>> map_items({'a': 1, 'b': 2}, str.upper, str)
+        {'A': '1', 'B': '2'}
+    """
+    items = [
+        (original_key, key_func(original_key), value_func(value))
+        for original_key, value in dic.items()
+    ]
+    # duplicate keys are not allowed in a dictionary
+    keys = set()
+    for original_key, new_key, _ in items:
+        if new_key in keys:
+            raise KeyError(
+                f"Duplicate mapped key: {new_key} from original key: {original_key}"
+            )
+        keys.add(new_key)
+    return {new_key: value for _, new_key, value in items}
+
+
+__all__ = [
+    "map_keys",
+    "map_values",
+    "map_items",
+]

--- a/dict_zip/tuple_keys.py
+++ b/dict_zip/tuple_keys.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+from typing import TypeVar
+
+from .dict_map import map_keys
+
+
+T = TypeVar("T")
+S = TypeVar("S")
+
+
+def tuple_keys(dic: dict[T, S]) -> dict[tuple[T], S]:
+    """Convert the keys of a dictionary to tuples.
+    Args:
+        dic: The dictionary to convert.
+    Returns:
+        A new dictionary with the keys converted to tuples.
+    Example:
+        >>> from dict_zip import tuple_keys
+        >>> tuple_keys({'a': 1, 'b': 2})
+        {('a',): 1, ('b',): 2}
+    """
+    return map_keys(dic, lambda k: (k,))

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,0 +1,62 @@
+import pytest
+
+from dict_zip import (
+    map_keys,
+    map_values,
+    map_items,
+)
+
+
+def test_map_keys() -> None:
+    d = {"a": 1, "b": 2}
+    assert map_keys(d, str.upper) == {"A": 1, "B": 2}
+    assert map_keys(d, lambda x: x + "!") == {"a!": 1, "b!": 2}
+    assert map_keys({("a", "b"): 1, ("c", "d"): 2}, lambda x: "".join(x)) == {
+        "ab": 1,
+        "cd": 2,
+    }
+
+    # empty dictionary
+    d2: dict[str, int] = {}
+    assert map_keys(d2, str.upper) == {}
+    assert map_keys(d2, lambda x: x + "!") == {}
+
+    # duplicate keys
+    with pytest.raises(KeyError):
+        map_keys({"a1": 1, "a2": 2}, lambda x: x[0])
+
+
+def test_map_values() -> None:
+    d = {"a": 1, "b": 2}
+    assert map_values(d, str) == {"a": "1", "b": "2"}
+    assert map_values(d, lambda x: x + 1) == {"a": 2, "b": 3}
+    assert map_values({("a", "b"): 1, ("c", "d"): 2}, lambda x: x * 2) == {
+        ("a", "b"): 2,
+        ("c", "d"): 4,
+    }
+
+    # empty dictionary
+    d2: dict[str, int] = {}
+    assert map_values(d2, str) == {}
+    assert map_values(d2, lambda x: x + 1) == {}
+
+
+def test_map_items() -> None:
+    d = {"a": 1, "b": 2}
+    assert map_items(d, str.upper, str) == {"A": "1", "B": "2"}
+    assert map_items(d, lambda x: x + "!", lambda x: x * 2) == {
+        "a!": 2,
+        "b!": 4,
+    }
+    assert map_items(
+        {("a", "b"): 1, ("c", "d"): 2}, lambda x: "".join(x), lambda x: x * 2
+    ) == {"ab": 2, "cd": 4}
+
+    # empty dictionary
+    d2: dict[str, int] = {}
+    assert map_items(d2, str.upper, str) == {}
+    assert map_items(d2, lambda x: x + "!", lambda x: x * 2) == {}
+
+    # duplicate keys
+    with pytest.raises(KeyError):
+        map_items({"a1": 1, "a2": 2}, lambda x: x[0], lambda x: x * 2)

--- a/tests/test_tuple_keys.py
+++ b/tests/test_tuple_keys.py
@@ -1,0 +1,6 @@
+from dict_zip import tuple_keys
+
+
+def test_tuple_keys() -> None:
+    d = {"a": 1, "b": 2}
+    assert tuple_keys(d) == {("a",): 1, ("b",): 2}


### PR DESCRIPTION
 ## map_keys, map_values, map_items

`map_keys`, `map_values`, and `map_items` are used to map keys, values, and items of dict.

```python
>>> from dict_zip import map_keys
>>> map_keys({'a': 1, 'b': 2}, str.upper)
{'A': 1, 'B': 2}
>>> from dict_zip import map_values
>>> map_values({'a': 1, 'b': 2}, str)
{'a': '1', 'b': '2'}
>>> from dict_zip import map_items
>>> map_items({'a': 1, 'b': 2}, str.upper, str)
{'A': '1', 'B': '2'}
```

 ## tuple_keys

`tuple_keys` is used to convert dict keys to tuple.

```python
>>> from dict_zip import tuple_keys
>>> tuple_keys({'a': 1, 'b': 2})
{('a',): 1, ('b',): 2}
```
