### PR TITLE
Tighten Ruff McCabe complexity limit

### DIFF
--- a/dict_zip/dict_zip.py
+++ b/dict_zip/dict_zip.py
@@ -104,13 +104,13 @@ def dict_zip(*dictionaries):  # type: ignore[no-untyped-def]
     common_keys = functools.reduce(
         lambda x, y: x & y, (set(d.keys()) for d in dictionaries),
     )
-    return_dic = {}  # type: ignore[var-annotated]
-    for dic in dictionaries:
-        for key, val in dic.items():
-            if key in common_keys:
-                return_dic.setdefault(key, []).append(val)
-
-    return {key: tuple(val) for key, val in return_dic.items()}
+    ordered_common_keys = [
+        key for key in dictionaries[0] if key in common_keys
+    ]
+    return {
+        key: tuple(dictionary[key] for dictionary in dictionaries)
+        for key in ordered_common_keys
+    }
 
 
 __all__ = ["dict_zip"]

--- a/dict_zip/dict_zip_longest.py
+++ b/dict_zip/dict_zip_longest.py
@@ -9,7 +9,8 @@ Example:
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, TypeVar, overload
+from itertools import chain
+from typing import TypeVar, overload
 
 _K = TypeVar("_K")
 _Fill = TypeVar("_Fill")
@@ -283,23 +284,16 @@ def dict_zip_longest(*dictionaries, fillvalue=None):  # type: ignore[no-untyped-
     {'a': (1, 3), 'b': (2, 4), 'c': (4, None)}
     """
     all_keys = __all_keys(d.keys() for d in dictionaries)
-    return_dic: dict[Any, tuple[Any, ...]] = dict.fromkeys(all_keys, ())
-
-    for dic in dictionaries:
-        for key in all_keys:
-            return_dic[key] += (dic.get(key, fillvalue),)
-
-    return return_dic
+    return {
+        key: tuple(
+            dictionary.get(key, fillvalue) for dictionary in dictionaries
+        )
+        for key in all_keys
+    }
 
 
 def __all_keys(iterables: Iterable[Iterable[_K]]) -> list[_K]:
-    keys = []
-    for iterable in iterables:
-        for key in iterable:
-            if key in keys:
-                continue
-            keys.append(key)
-    return keys
+    return list(dict.fromkeys(chain.from_iterable(iterables)))
 
 
 __all__ = ["dict_zip_longest"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 4
+max-complexity = 3
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ ignore = [
     "S101",
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 4
+
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 


### PR DESCRIPTION
## Summary
- add Ruff McCabe `max-complexity = 4`
- lower the limit to `3`
- simplify dictionary zipping helpers while preserving key order semantics

## Testing
- `uv run poe check`
- `uv run poe test`