### PR TITLE
ci: restrict workflow permissions for pypi publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,9 +10,14 @@ on:
 env:
   python_version: 3.13
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Set explicit workflow/job permissions for the PyPI publish workflow to enforce minimum scope.

- Add top-level `permissions: contents: read`
- Add job-level `permissions: contents: read` for `deploy` job
- Keep publish guards on `pull_request` / `release` event conditions unchanged

## Validation

- `uv sync`
- `uv run poe check`
- `uv run poe test`
