### PR TITLE
fix: return empty dict for zero-argument call

### DIFF
--- a/dict_zip/dict_zip.py
+++ b/dict_zip/dict_zip.py
@@ -24,6 +24,8 @@ _T9 = TypeVar("_T9")
 
 
 @overload
+def dict_zip() -> dict[object, tuple[()]]: ...
+@overload
 def dict_zip(dict1: dict[_K, _T1]) -> dict[_K, tuple[_T1]]: ...
 @overload
 def dict_zip(
@@ -101,6 +103,9 @@ def dict_zip(*dictionaries):  # type: ignore[no-untyped-def]
     >>> dict_zip({'a': 1, 'b': 2}, {'a': 3, 'b': 4})
     {'a': (1, 3), 'b': (2, 4)}
     """
+    if not dictionaries:
+        return {}
+
     common_keys = functools.reduce(
         lambda x, y: x & y, (set(d.keys()) for d in dictionaries),
     )

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -1,6 +1,10 @@
 from dict_zip import dict_zip, dict_zip_longest
 
 
+def test_dict_zip_without_dictionaries() -> None:
+    assert dict_zip() == {}
+
+
 def test_basis() -> None:
     d1 = {"a": 1, "b": 2, "c": 3}
     d2 = {"a": 4, "b": 5}


### PR DESCRIPTION
## Summary
- Return `{}` when `dict_zip()` is called without dictionaries.
- Add a focused contract test for the zero-argument call.
- Add a zero-argument overload so the supported runtime behavior is visible to type checkers.

## Root cause
`dict_zip()` previously always reduced the input dictionary key sets. With no input dictionaries, `functools.reduce` received an empty iterable and raised a runtime exception before a result could be built.

## Validation
- `uv sync`
- `uv run poe check`
- `uv run poe test`
