### PR TITLE
Pin PyPI publish workflow actions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,10 +19,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
         with:
           enable-cache: true
 
@@ -34,7 +34,7 @@ jobs:
         run: uv build
 
       - name: Publish distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
           user: __token__
@@ -43,7 +43,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin the PyPI publish workflow actions to their current commit SHAs.
- Keep the release triggers, permissions, build step, and TestPyPI/PyPI publish conditions unchanged.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pypi-publish.yml")'`
- `actionlint .github/workflows/pypi-publish.yml`
- `uv sync`
- `uv run poe check`
- `uv run poe test`
- `uv build`

`uv build` completes successfully. It still emits the existing setuptools license deprecation warnings from the current package metadata.

Publish steps for TestPyPI and PyPI were not run.
