### PR TITLE
Pin reusable workflow refs

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   update-gitignore:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/gitignore-in.yml@0b691527a4dde052c79eae22706131a7726a2bba

--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -7,4 +7,4 @@ permissions:
   issues: write
 jobs:
   happy:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@0b691527a4dde052c79eae22706131a7726a2bba


### PR DESCRIPTION
## Summary
- pin the reusable happy-commit workflow ref to the current gh-actions-workflows commit
- pin the reusable gitignore update workflow ref to the same immutable commit

## Verification
- actionlint .github/workflows/happy.yml .github/workflows/gitignore-in.yml
- git diff --check