### PR TITLE
Set Python test workflow token permissions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -44,4 +48,3 @@ jobs:
 
       - name: Coverage
         run: uv run poe coverage-xml
-


### PR DESCRIPTION
## Summary
- set the Python test workflow GITHUB_TOKEN permissions to read-only contents access
- avoid relying on repository default workflow token permissions for test jobs

## Verification
- actionlint -shellcheck= .github/workflows/python-test.yml
- git diff --check
- uv run poe check
- uv run poe test
- uv run poe coverage-xml

## Note
- Plain actionlint currently reports a pre-existing ShellCheck warning in the inline Python version check script; this PR does not change that script.