### PR TITLE
Drop undefined names from dict_zip __all__

### DIFF
--- a/dict_zip/__init__.py
+++ b/dict_zip/__init__.py
@@ -30,8 +30,6 @@ __all__ = [
     "dict_zip_longest",
     "map_items",
     "map_keys",
-    "map_keys_first",
-    "map_keys_last",
     "map_values",
     "tuple_keys",
 ]

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -1,0 +1,21 @@
+import importlib
+
+import dict_zip
+
+
+def test_star_import_resolves_all_entries() -> None:
+    namespace: dict[str, object] = {}
+    exec("from dict_zip import *", namespace)  # noqa: S102
+
+    for name in dict_zip.__all__:
+        assert name in namespace, (
+            f"{name} listed in __all__ but missing from import *"
+        )
+
+
+def test_all_entries_are_attributes() -> None:
+    module = importlib.import_module("dict_zip")
+    for name in module.__all__:
+        assert hasattr(module, name), (
+            f"{name} listed in __all__ but not defined on module"
+        )


### PR DESCRIPTION
## Summary

- `dict_zip/__init__.py` listed `map_keys_first` and `map_keys_last` in `__all__`, but neither function was implemented or imported. As a result, `from dict_zip import *` raised `ImportError`, and tools that read `__all__` saw a public surface that did not match the module.
- Drop the two stale entries from `__all__` so the declared public surface matches what the package actually exports. Because neither function is planned to be implemented, the deletion does not break any caller (only previously-broken paths such as `from dict_zip import map_keys_first` are affected).
- Add `tests/test_public_surface.py` to lock down the smoke test that every entry in `__all__` resolves both via the `from dict_zip import *` namespace and via module attributes. Future drift where `__all__` is updated without the corresponding implementation will fail in CI.

## Test plan

- [x] `uv run poe check` (ruff + mypy)
- [x] `uv run poe test` (pytest)
- [x] `uv run poe coverage-xml`