### PR TITLE
Pin workflow action refs

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Enable caching
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@13bcb6950cf9b54297b7e8f88823dcd2c45426b2 # main


### PR DESCRIPTION
## Summary
- Pin the Python test workflow checkout and setup-uv actions to full commit SHAs.
- Pin the reusable spellcheck workflow to the current upstream `main` commit.
- Keep version comments next to pinned refs for maintainability.

## Verification
- `git diff --check`
- `actionlint -ignore 'SC2081' .github/workflows/*.yml`
- Verified every workflow `uses:` ref is pinned to a 40-character SHA.