### PR TITLE
Add concurrency controls to GitHub Actions workflows

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -1,6 +1,11 @@
 name: happy-commit
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,6 +7,10 @@ on:
     # "released" events are emitted either when directly be released or be edited from pre-released.
     types: [prereleased, released]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 env:
   python_version: 3.13
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,6 +1,11 @@
 name: Spellcheck
 on:
   - pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## Summary

Add top-level `concurrency` settings to the GitHub Actions workflows for CI, coverage, publishing, and spellcheck.

The concurrency group is:

`${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`

This ensures that newer runs for the same pull request or branch cancel older in-progress runs, reducing redundant workflow execution.

## Details

- Added `concurrency` blocks to workflows triggered by `pull_request` and/or `push`
- Enabled `cancel-in-progress` only for `pull_request` and `push` events
- Kept release-triggered packaging and publishing runs unaffected by this cancellation behavior

## Verification

- `git diff --check`
- `actionlint -shellcheck= .github/workflows/*.yml`
- `typos .github/workflows/*.yml`
