### PR TITLE
fix: correct Python version check in CI workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
+          python-version: ${{ matrix.python }}
 
       - name: Install dependencies
         run: uv sync
@@ -41,8 +42,8 @@ jobs:
       - name: Check Python version
         run: |
           actual_version=$(uv run python --version)
-          expected_version="Python ${{ matrix.python }}"
-          if [ "$actual_version" == *"$expected_version"* ]; then
+          expected_version="${{ matrix.python }}"
+          if [[ "$actual_version" != *"$expected_version"* ]]; then
             echo "Expected $expected_version, but got $actual_version"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Fix two bugs in the "Check Python version" CI step that prevented it from
actually verifying the Python version used in each matrix job.

### Problems

1. **Inverted condition**: `[ "$actual" == *"$expected"* ]` called `exit 1`
   when the version *matched*, and silently passed when it didn't.
2. **POSIX `[ ]` doesn't support glob patterns**: `==` with `*...*` globs
   requires `[[ ]]` (bash conditional). With `[ ]`, the pattern is treated as
   a literal string, so the condition was always false and `exit 1` was
   never reached.

As a result, the version check was a no-op — any Python version would pass
silently regardless of what `matrix.python` specified.

### Changes

- `setup-uv`: add `python-version: ${{ matrix.python }}` so uv explicitly
  installs and uses the matrix-specified Python version.
- `Check Python version`: switch to `[[ ]]` for glob matching, invert the
  condition to `!=` (fail when version does *not* match), and simplify
  `expected_version` to the bare version string (e.g. `3.10`) since
  `python --version` already contains it.

## Test plan

- CI matrix jobs (Python 3.10–3.14) should each verify the correct interpreter
  is active.
- A deliberate mismatch (e.g. `matrix.python: 3.10` with a 3.11 install) would
  now correctly fail the step.
