### PR TITLE
Check mapped key duplicates before mapping values

### DIFF
--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -75,20 +75,19 @@ def map_items(
         >>> map_items({'a': 1, 'b': 2}, str.upper, str)
         {'A': '1', 'B': '2'}
     """
-    items = [
-        (original_key, key_func(original_key), value_func(value))
-        for original_key, value in dic.items()
-    ]
     # duplicate keys are not allowed in a dictionary
-    keys = set()
-    for original_key, new_key, _ in items:
+    keys: set[U] = set()
+    result: dict[U, T] = {}
+    for original_key, value in dic.items():
+        new_key = key_func(original_key)
         if new_key in keys:
             raise KeyError(
                 "Duplicate mapped key: "
                 f"{new_key} from original key: {original_key}",
             )
         keys.add(new_key)
-    return {new_key: value for _, new_key, value in items}
+        result[new_key] = value_func(value)
+    return result
 
 
 __all__ = [

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -49,7 +49,9 @@ def test_map_items() -> None:
         "b!": 4,
     }
     assert map_items(
-        {("a", "b"): 1, ("c", "d"): 2}, lambda x: "".join(x), lambda x: x * 2,
+        {("a", "b"): 1, ("c", "d"): 2},
+        lambda x: "".join(x),
+        lambda x: x * 2,
     ) == {"ab": 2, "cd": 4}
 
     # empty dictionary
@@ -60,3 +62,16 @@ def test_map_items() -> None:
     # duplicate keys
     with pytest.raises(KeyError):
         map_items({"a1": 1, "a2": 2}, lambda x: x[0], lambda x: x * 2)
+
+
+def test_map_items_checks_duplicate_keys_before_mapping_values() -> None:
+    mapped_values: list[int] = []
+
+    def map_value(value: int) -> int:
+        mapped_values.append(value)
+        return value * 2
+
+    with pytest.raises(KeyError):
+        map_items({"a1": 1, "a2": 2}, lambda key: key[0], map_value)
+
+    assert mapped_values == [1]


### PR DESCRIPTION
## Summary
- Check mapped key duplicates while iterating instead of after eagerly building an intermediate item list.
- Avoid calling `value_func` for the item that first creates a duplicate mapped key.
- Add a regression test for `value_func` side effects when duplicate mapped keys are detected.

## Test plan
- `uv run ruff format --check dict_zip/dict_map.py tests/test_map.py`
- `uv run poe check`
- `uv run poe test`
