### PR TITLE
Accept func as a map_items key mapper alias

### DIFF
--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -3,12 +3,39 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypeVar
+from typing import TypeVar, cast, overload
 
 K = TypeVar("K")
 V = TypeVar("V")
 U = TypeVar("U")
 T = TypeVar("T")
+
+
+_MISSING = object()
+
+
+def _resolve_key_mapper(
+    key_func: Callable[[K], U] | None,
+    func: Callable[[K], U] | None,
+) -> Callable[[K], U]:
+    mappers = tuple(
+        mapper for mapper in (key_func, func) if mapper is not None
+    )
+    if len(mappers) == 1:
+        return mappers[0]
+    raise TypeError(
+        "map_items() missing required argument: 'key_func'"
+        if not mappers
+        else "map_items() got both 'key_func' and 'func'",
+    )
+
+
+def _resolve_value_mapper(
+    value_func: Callable[[V], T] | object,
+) -> Callable[[V], T]:
+    if value_func is _MISSING:
+        raise TypeError("map_items() missing required argument: 'value_func'")
+    return cast("Callable[[V], T]", value_func)
 
 
 def map_keys(dic: dict[K, V], func: Callable[[K], U]) -> dict[U, V]:
@@ -55,10 +82,30 @@ def map_values(dic: dict[K, V], func: Callable[[V], U]) -> dict[K, U]:
     return map_items(dic, lambda k: k, func)
 
 
+@overload
 def map_items(
     dic: dict[K, V],
     key_func: Callable[[K], U],
     value_func: Callable[[V], T],
+) -> dict[U, T]: ...
+
+
+@overload
+def map_items(
+    dic: dict[K, V],
+    key_func: None = None,
+    value_func: Callable[[V], T] = ...,
+    *,
+    func: Callable[[K], U],
+) -> dict[U, T]: ...
+
+
+def map_items(
+    dic: dict[K, V],
+    key_func: Callable[[K], U] | None = None,
+    value_func: Callable[[V], T] | object = _MISSING,
+    *,
+    func: Callable[[K], U] | None = None,
 ) -> dict[U, T]:
     """Apply a function to the keys and values of a dictionary.
 
@@ -66,6 +113,7 @@ def map_items(
         dic: The dictionary to map.
         key_func: The function to apply to the keys.
         value_func: The function to apply to the values.
+        func: Alias for key_func.
 
     Returns:
         A new dictionary with the keys and values transformed by the functions.
@@ -74,19 +122,23 @@ def map_items(
         >>> from dict_zip import map_items
         >>> map_items({'a': 1, 'b': 2}, str.upper, str)
         {'A': '1', 'B': '2'}
+        >>> map_items({'a': 1, 'b': 2}, func=str.upper, value_func=str)
+        {'A': '1', 'B': '2'}
     """
+    key_mapper = _resolve_key_mapper(key_func, func)
+    value_mapper: Callable[[V], T] = _resolve_value_mapper(value_func)
     # duplicate keys are not allowed in a dictionary
     keys: set[U] = set()
     result: dict[U, T] = {}
     for original_key, value in dic.items():
-        new_key = key_func(original_key)
+        new_key = key_mapper(original_key)
         if new_key in keys:
             raise KeyError(
                 "Duplicate mapped key: "
                 f"{new_key} from original key: {original_key}",
             )
         keys.add(new_key)
-        result[new_key] = value_func(value)
+        result[new_key] = value_mapper(value)
     return result
 
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 import pytest
 
 from dict_zip import (
@@ -62,6 +64,34 @@ def test_map_items() -> None:
     # duplicate keys
     with pytest.raises(KeyError):
         map_items({"a1": 1, "a2": 2}, lambda x: x[0], lambda x: x * 2)
+
+
+def test_map_items_accepts_func_alias_for_key_func() -> None:
+    d = {"a": 1, "b": 2}
+
+    assert map_items(d, func=str.upper, value_func=str) == {
+        "A": "1",
+        "B": "2",
+    }
+
+
+def test_map_items_rejects_ambiguous_key_function_alias() -> None:
+    d = {"a": 1, "b": 2}
+    unchecked_map_items = cast(Any, map_items)
+
+    with pytest.raises(TypeError, match="both 'key_func' and 'func'"):
+        unchecked_map_items(d, str.upper, str, func=str.lower)
+
+
+def test_map_items_rejects_missing_key_function() -> None:
+    d = {"a": 1, "b": 2}
+    unchecked_map_items = cast(Any, map_items)
+
+    with pytest.raises(
+        TypeError,
+        match="missing required argument: 'key_func'",
+    ):
+        unchecked_map_items(d, value_func=str)
 
 
 def test_map_items_checks_duplicate_keys_before_mapping_values() -> None:


### PR DESCRIPTION
## Summary
- add `func=` as a keyword alias for the `map_items` key mapper
- keep existing `key_func` calls working and reject ambiguous `key_func` plus `func` usage
- cover the compatibility path and error cases in `tests/test_map.py`

## Tests
- `uv run ruff format dict_zip/dict_map.py tests/test_map.py`
- `uv run poe check`
- `uv run poe test`
