### PR TITLE
docs: add Raises section to map_keys and map_items docstrings

### DIFF
--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -21,6 +21,10 @@ def map_keys(dic: dict[K, V], func: Callable[[K], U]) -> dict[U, V]:
     Returns:
         A new dictionary with the same values and transformed keys.
 
+    Raises:
+        KeyError: If two different keys in ``dic`` are mapped to the same key
+            by ``func``.
+
     Example:
         >>> from dict_zip import map_keys
         >>> map_keys({'a': 1, 'b': 2}, str.upper)
@@ -69,6 +73,10 @@ def map_items(
 
     Returns:
         A new dictionary with the keys and values transformed by the functions.
+
+    Raises:
+        KeyError: If ``key_func`` maps two different keys in ``dic`` to the
+            same key.
 
     Example:
         >>> from dict_zip import map_items

--- a/dict_zip/dict_zip.py
+++ b/dict_zip/dict_zip.py
@@ -29,11 +29,14 @@ def dict_zip() -> dict[object, tuple[()]]: ...
 def dict_zip(dict1: dict[_K, _T1]) -> dict[_K, tuple[_T1]]: ...
 @overload
 def dict_zip(
-    dict1: dict[_K, _T1], dict2: dict[_K, _T2],
+    dict1: dict[_K, _T1],
+    dict2: dict[_K, _T2],
 ) -> dict[_K, tuple[_T1, _T2]]: ...
 @overload
 def dict_zip(
-    dict1: dict[_K, _T1], dict2: dict[_K, _T2], dict3: dict[_K, _T3],
+    dict1: dict[_K, _T1],
+    dict2: dict[_K, _T2],
+    dict3: dict[_K, _T3],
 ) -> dict[_K, tuple[_T1, _T2, _T3]]: ...
 @overload
 def dict_zip(
@@ -107,7 +110,8 @@ def dict_zip(*dictionaries):  # type: ignore[no-untyped-def]
         return {}
 
     common_keys = functools.reduce(
-        lambda x, y: x & y, (set(d.keys()) for d in dictionaries),
+        lambda x, y: x & y,
+        (set(d.keys()) for d in dictionaries),
     )
     ordered_common_keys = [
         key for key in dictionaries[0] if key in common_keys

--- a/dict_zip/dict_zip_longest.py
+++ b/dict_zip/dict_zip_longest.py
@@ -29,11 +29,14 @@ _T9 = TypeVar("_T9")
 def dict_zip_longest(dict1: dict[_K, _T1]) -> dict[_K, tuple[_T1 | None]]: ...
 @overload
 def dict_zip_longest(
-    dict1: dict[_K, _T1], *, fillvalue: _Fill | None = None,
+    dict1: dict[_K, _T1],
+    *,
+    fillvalue: _Fill | None = None,
 ) -> dict[_K, tuple[_T1 | _Fill]]: ...
 @overload
 def dict_zip_longest(
-    dict1: dict[_K, _T1], dict2: dict[_K, _T2],
+    dict1: dict[_K, _T1],
+    dict2: dict[_K, _T2],
 ) -> dict[_K, tuple[_T1 | None, _T2 | None]]: ...
 @overload
 def dict_zip_longest(
@@ -44,7 +47,9 @@ def dict_zip_longest(
 ) -> dict[_K, tuple[_T1 | _Fill, _T2 | _Fill]]: ...
 @overload
 def dict_zip_longest(
-    dict1: dict[_K, _T1], dict2: dict[_K, _T2], dict3: dict[_K, _T3],
+    dict1: dict[_K, _T1],
+    dict2: dict[_K, _T2],
+    dict3: dict[_K, _T3],
 ) -> dict[_K, tuple[_T1 | None, _T2 | None, _T3 | None]]: ...
 @overload
 def dict_zip_longest(
@@ -78,7 +83,8 @@ def dict_zip_longest(
     dict4: dict[_K, _T4],
     dict5: dict[_K, _T5],
 ) -> dict[
-    _K, tuple[_T1 | None, _T2 | None, _T3 | None, _T4 | None, _T5 | None],
+    _K,
+    tuple[_T1 | None, _T2 | None, _T3 | None, _T4 | None, _T5 | None],
 ]: ...
 @overload
 def dict_zip_longest(
@@ -90,7 +96,8 @@ def dict_zip_longest(
     *,
     fillvalue: _Fill | None = None,
 ) -> dict[
-    _K, tuple[_T1 | _Fill, _T2 | _Fill, _T3 | _Fill, _T4 | _Fill, _T5 | _Fill],
+    _K,
+    tuple[_T1 | _Fill, _T2 | _Fill, _T3 | _Fill, _T4 | _Fill, _T5 | _Fill],
 ]: ...
 @overload
 def dict_zip_longest(
@@ -103,7 +110,12 @@ def dict_zip_longest(
 ) -> dict[
     _K,
     tuple[
-        _T1 | None, _T2 | None, _T3 | None, _T4 | None, _T5 | None, _T6 | None,
+        _T1 | None,
+        _T2 | None,
+        _T3 | None,
+        _T4 | None,
+        _T5 | None,
+        _T6 | None,
     ],
 ]: ...
 @overload

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,3 @@
-
 from dict_zip import dict_zip, dict_zip_longest
 
 d1: dict[str, int] = {"a": 1, "b": 2, "c": 3}


### PR DESCRIPTION
## Summary

- Added `Raises` section to `map_keys` docstring: documents that `KeyError` is raised when `func` maps two different keys to the same output key
- Added `Raises` section to `map_items` docstring: documents that `KeyError` is raised when `key_func` maps two different keys to the same output key
- `map_values` is not affected: it uses the identity function as `key_func`, so duplicate keys cannot arise

The `KeyError` behavior was already implemented and tested (`pytest.raises(KeyError)` in `tests/test_map.py`), but was not reflected in the public API documentation.

## Test plan

- [x] All 11 existing unit tests pass (`pytest`)
- [x] All 10 doctests pass (`python -m doctest dict_zip/dict_map.py`)
- [x] `ruff format` and `ruff check` pass with no issues
