### PR TITLE
Clarify map_items key mapper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ It fills with fillvalue (default: `None`) when argument dict doesn't have match 
 {'A': '1', 'B': '2'}
 ```
 
+`map_items` accepts the key mapper as the second positional argument. The
+keyword-only `func=` argument is kept as a backward-compatible alias for
+`key_func`.
+
 ## tuple_keys
 
 `tuple_keys` is used to convert dict keys to tuple.

--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TypeVar, cast, overload
+from typing import NoReturn, TypeVar, cast, overload
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -12,6 +12,7 @@ T = TypeVar("T")
 
 
 _MISSING = object()
+_MISSING_VALUE_FUNC = cast("Callable[[object], NoReturn]", _MISSING)
 
 
 def _resolve_key_mapper(
@@ -31,11 +32,11 @@ def _resolve_key_mapper(
 
 
 def _resolve_value_mapper(
-    value_func: Callable[[V], T] | object,
+    value_func: Callable[[V], T],
 ) -> Callable[[V], T]:
     if value_func is _MISSING:
         raise TypeError("map_items() missing required argument: 'value_func'")
-    return cast("Callable[[V], T]", value_func)
+    return value_func
 
 
 def map_keys(dic: dict[K, V], func: Callable[[K], U]) -> dict[U, V]:
@@ -107,7 +108,7 @@ def map_items(
 def map_items(
     dic: dict[K, V],
     key_func: Callable[[K], U] | None = None,
-    value_func: Callable[[V], T] | object = _MISSING,
+    value_func: Callable[[V], T] = _MISSING_VALUE_FUNC,
     *,
     func: Callable[[K], U] | None = None,
 ) -> dict[U, T]:
@@ -115,9 +116,10 @@ def map_items(
 
     Args:
         dic: The dictionary to map.
-        key_func: The function to apply to the keys.
+        key_func: The function to apply to the keys. Prefer this positional
+            argument for new code.
         value_func: The function to apply to the values.
-        func: Alias for key_func.
+        func: Backward-compatible keyword-only alias for ``key_func``.
 
     Returns:
         A new dictionary with the keys and values transformed by the functions.

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -75,6 +75,10 @@ def test_map_items_accepts_func_alias_for_key_func() -> None:
     }
 
 
+def test_map_items_value_func_annotation_hides_internal_sentinel() -> None:
+    assert "object" not in map_items.__annotations__["value_func"]
+
+
 def test_map_items_rejects_ambiguous_key_function_alias() -> None:
     d = {"a": 1, "b": 2}
     unchecked_map_items = cast(Any, map_items)


### PR DESCRIPTION
## Summary

- Clarify in `README.md` and `dict_zip/dict_map.py` that `key_func` is the preferred key mapper argument for `map_items`.
- Keep `func=` documented as a backward-compatible keyword-only alias.
- Hide the internal missing-value sentinel from the public `value_func` annotation and add a regression test in `tests/test_map.py`.

## Verification

- `uv run ruff format dict_zip tests`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
