### PR TITLE
fix(map): raise ValueError for duplicate mapped keys

### DIFF
--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -50,7 +50,7 @@ def map_keys(dic: dict[K, V], func: Callable[[K], U]) -> dict[U, V]:
         A new dictionary with the same values and transformed keys.
 
     Raises:
-        KeyError: If two different keys in ``dic`` are mapped to the same key
+        ValueError: If two different keys in ``dic`` are mapped to the same key
             by ``func``.
 
     Example:
@@ -125,7 +125,7 @@ def map_items(
         A new dictionary with the keys and values transformed by the functions.
 
     Raises:
-        KeyError: If ``key_func`` maps two different keys in ``dic`` to the
+        ValueError: If ``key_func`` maps two different keys in ``dic`` to the
             same key.
 
     Example:
@@ -143,7 +143,7 @@ def map_items(
     for original_key, value in dic.items():
         new_key = key_mapper(original_key)
         if new_key in keys:
-            raise KeyError(
+            raise ValueError(
                 "Duplicate mapped key: "
                 f"{new_key} from original key: {original_key}",
             )

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -24,7 +24,7 @@ def test_map_keys() -> None:
     assert map_keys(d2, lambda x: x + "!") == {}
 
     # duplicate keys
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Duplicate mapped key: a"):
         map_keys({"a1": 1, "a2": 2}, lambda x: x[0])
 
 
@@ -62,7 +62,7 @@ def test_map_items() -> None:
     assert map_items(d2, lambda x: x + "!", lambda x: x * 2) == {}
 
     # duplicate keys
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Duplicate mapped key: a"):
         map_items({"a1": 1, "a2": 2}, lambda x: x[0], lambda x: x * 2)
 
 
@@ -105,7 +105,7 @@ def test_map_items_checks_duplicate_keys_before_mapping_values() -> None:
         mapped_values.append(value)
         return value * 2
 
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError, match="Duplicate mapped key: a"):
         map_items({"a1": 1, "a2": 2}, lambda key: key[0], map_value)
 
     assert mapped_values == [1]


### PR DESCRIPTION
## Summary
- Raise `ValueError` when key mappers produce duplicate output keys.
- Update `map_keys` and `map_items` docstrings to document the validation error.
- Keep duplicate detection before value mapping and cover the new exception type in tests.

## Tests
- `uv run poe format`
- `uv sync && uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
- `uv run ruff check dict_zip tests --select B,PLE,RUF,S`
