### PR TITLE
Add concurrency to gitignore update workflow

### DIFF
--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -5,6 +5,10 @@ on:
     # daily at 00:00
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
- Add a workflow-level concurrency group to `.github/workflows/gitignore-in.yml`.
- Cancel overlapping scheduled gitignore update runs for the same workflow/ref.

## Validation
- `actionlint .github/workflows/gitignore-in.yml`
- `git diff --check`
- `uv run poe check`
- `uv run poe test`
