### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ dict_zip supports for type hints.
 
 <img width="535" alt="screen-shot-of-type-hints" src="https://user-images.githubusercontent.com/2596972/181838389-2860e45c-b366-41e4-83a1-f747b7115a5f.png">
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # LICENSE
 
 The 3-Clause BSD License. See also LICENSE file.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so the same checks CI runs are available locally via Git hooks
- CI (GitHub Actions) is kept entirely unchanged — Actions is free for public repos; the hooks only surface problems earlier on your local machine

## Changes

- `lefthook.yml`: defines `pre-commit` (runs `uv run poe check`) and `pre-push` (runs `uv run poe check` + `uv run poe test`), with GIT_* environment variable cleanup to avoid affecting nested/sibling repositories
- `README.md`: adds a `## Development` section (inserted before the existing `# LICENSE` section) explaining how to install and use the hooks

## Verification

- `uv run poe check` passes locally (ruff + mypy, no issues)
- `uv run poe test` passes locally (15/15 tests pass)
- Pre-commit hook fired and passed during the commit
- Pre-push hook fired (check + test) and passed during `git push`

## Notes

- Requires `lefthook` on your PATH (`lefthook install` to activate hooks once)
- No CI workflows were modified
