### PR TITLE
ci: migrate PyPI publish to OIDC Trusted Publishers

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
@@ -41,13 +42,8 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         if: github.event_name == 'release' && github.event.release.prerelease
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish distribution to PyPI
         if: github.event_name == 'release' && !github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

Migrate `.github/workflows/pypi-publish.yml` from legacy API token authentication to OIDC Trusted Publishers.

**Changes:**
- Add `id-token: write` permission to the `deploy` job
- Remove `user: __token__` and `password:` fields from both PyPI and Test PyPI publish steps

## Why

PyPI's [Trusted Publishers](https://docs.pypi.org/trusted-publishers/) (available since 2023) issues short-lived OIDC tokens per GitHub Actions run, eliminating the need to store long-lived API tokens in repository secrets.

With legacy token auth (`secrets.PYPI_API_TOKEN`):
- A leaked secret allows arbitrary publishes at any time
- Tokens have no expiry and require manual revocation
- Token rotation must be managed manually

## What changes

`pypa/gh-action-pypi-publish` already supports Trusted Publishers. The workflow-side change is minimal:
- Add `id-token: write` to `permissions`
- Remove `user` / `password` from the publish steps

The action automatically uses OIDC when no credentials are provided.

## Required action after merge

Before this workflow can publish successfully, a **Trusted Publisher must be configured on PyPI**:

1. Go to https://pypi.org/manage/project/dict-zip/settings/publishing/ (and https://test.pypi.org/manage/project/dict-zip/settings/publishing/ for Test PyPI)
2. Add a new "GitHub Actions" publisher with:
   - Owner: `kitsuyui`
   - Repository: `dict_zip`
   - Workflow: `pypi-publish.yml`
   - Environment: (leave blank)

Until the Trusted Publisher is configured, the publish steps will fail — but build and test steps are unaffected.
