### PR TITLE
fix: update Pygments to 2.20.0 to resolve GHSA-5239-wwwm-4pmq

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-04-12T02:19:34.790275992Z"
+exclude-newer = "2026-06-11T02:51:41.275863Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -372,11 +372,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

Update Pygments from 2.19.2 to 2.20.0 in `uv.lock`.

## Why

Pygments < 2.20.0 is affected by [GHSA-5239-wwwm-4pmq](https://github.com/advisories/GHSA-5239-wwwm-4pmq) (low severity). Pygments is a transitive dependency pulled in by pytest. While the vulnerability impact on this project is minimal (it affects text highlighting in specific contexts not used directly), updating to 2.20.0 removes the open alert.

## Scope

- `uv.lock`: Pygments 2.19.2 → 2.20.0. No changes to `pyproject.toml` (no direct dependency; only the lock is updated).

## Verification

- `uv run poe test`: 15 tests pass.
- `uv run poe check`: ruff and mypy both pass with no issues.

## Trade-offs

- Lock-only update with no changes to declared dependencies. If upstream removes Pygments as a transitive dep of pytest in the future, this entry will disappear naturally from the lock.
