### PR TITLE
fix: include both original keys in duplicate mapped key error

### DIFF
--- a/dict_zip/dict_map.py
+++ b/dict_zip/dict_map.py
@@ -137,17 +137,18 @@ def map_items(
     """
     key_mapper = _resolve_key_mapper(key_func, func)
     value_mapper: Callable[[V], T] = _resolve_value_mapper(value_func)
-    # duplicate keys are not allowed in a dictionary
-    keys: set[U] = set()
+    key_origins: dict[U, K] = {}
     result: dict[U, T] = {}
     for original_key, value in dic.items():
         new_key = key_mapper(original_key)
-        if new_key in keys:
+        if new_key in key_origins:
+            first_key = key_origins[new_key]
             raise ValueError(
-                "Duplicate mapped key: "
-                f"{new_key} from original key: {original_key}",
+                f"Duplicate mapped key: {new_key}"
+                f" from original keys: {first_key!r}"
+                f" and {original_key!r}",
             )
-        keys.add(new_key)
+        key_origins[new_key] = original_key
         result[new_key] = value_mapper(value)
     return result
 

--- a/tests/test_map.py
+++ b/tests/test_map.py
@@ -98,6 +98,11 @@ def test_map_items_rejects_missing_key_function() -> None:
         unchecked_map_items(d, value_func=str)
 
 
+def test_map_items_duplicate_key_error_includes_both_original_keys() -> None:
+    with pytest.raises(ValueError, match=r"'a1'.*'a2'|'a2'.*'a1'"):
+        map_keys({"a1": 1, "a2": 2}, lambda x: x[0])
+
+
 def test_map_items_checks_duplicate_keys_before_mapping_values() -> None:
     mapped_values: list[int] = []
 


### PR DESCRIPTION
## Summary

When `map_items()` (and `map_keys()`) raises a `ValueError` for a duplicate
mapped key, the error message only showed the *second* original key that
triggered the collision — the *first* original key (already in the result)
was not reported.

Example before this fix:
```
ValueError: Duplicate mapped key: ab from original key: abd
```

The caller could not tell from the message alone which two keys collided; for
non-trivial key functions (`lambda k: k[:2]`, `operator.itemgetter(0)`, etc.)
finding the first key required manual inspection of the input dictionary.

## Changes

- `dict_zip/dict_map.py`: replaced `keys: set[U]` with
  `key_origins: dict[U, K]` to track the first original key for each mapped
  key. The error message now reports both colliding original keys.

  Example after this fix:
  ```
  ValueError: Duplicate mapped key: ab from original keys: 'abc' and 'abd'
  ```

- `tests/test_map.py`: added
  `test_map_items_duplicate_key_error_includes_both_original_keys` to assert
  that both original keys appear in the error message.

## Verification

- All 16 tests pass (`uv run poe test`).
- `ruff check` and `mypy` report no issues (`uv run poe check`).