### PR TITLE
Document output key order

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ $ pip install dict-zip
 ## dict_zip
 
 `dict_zip` is `zip` for dict.
+The result keeps the first dictionary's insertion order and skips keys
+missing from any dictionary.
 
 ```python
 >>> from dict_zip import dict_zip
@@ -30,6 +32,8 @@ $ pip install dict-zip
 
 `dict_zip_longest` is `zip_longest` for dict.
 It fills with fillvalue (default: `None`) when argument dict doesn't have match key.
+The result keeps keys in the order they are first seen while scanning the
+input dictionaries from left to right.
 
 ```python
 >>> from dict_zip import dict_zip_longest

--- a/dict_zip/dict_zip.py
+++ b/dict_zip/dict_zip.py
@@ -4,6 +4,9 @@ Example:
     >>> from dict_zip import dict_zip
     >>> dict_zip({'a': 1, 'b': 2}, {'a': 3, 'b': 4})
     {'a': (1, 3), 'b': (2, 4)}
+
+Result keys keep the first dictionary's insertion order, filtered to keys
+present in every dictionary.
 """
 
 from __future__ import annotations
@@ -102,6 +105,7 @@ def dict_zip(*dictionaries):  # type: ignore[no-untyped-def]
 
     The key is a common key shared by every dictionary.
     The value is a tuple with one value from each dictionary.
+    Result keys keep the first dictionary's insertion order.
 
     >>> dict_zip({'a': 1, 'b': 2}, {'a': 3, 'b': 4})
     {'a': (1, 3), 'b': (2, 4)}
@@ -109,12 +113,12 @@ def dict_zip(*dictionaries):  # type: ignore[no-untyped-def]
     if not dictionaries:
         return {}
 
-    common_keys = functools.reduce(
+    common_key_set = functools.reduce(
         lambda x, y: x & y,
         (set(d.keys()) for d in dictionaries),
     )
     ordered_common_keys = [
-        key for key in dictionaries[0] if key in common_keys
+        key for key in dictionaries[0] if key in common_key_set
     ]
     return {
         key: tuple(dictionary[key] for dictionary in dictionaries)

--- a/dict_zip/dict_zip_longest.py
+++ b/dict_zip/dict_zip_longest.py
@@ -4,6 +4,8 @@ Example:
     >>> from dict_zip import dict_zip_longest
     >>> dict_zip_longest({'a': 1, 'b': 2, 'c': 4}, {'a': 3, 'b': 4})
     {'a': (1, 3), 'b': (2, 4), 'c': (4, None)}
+
+Result keys keep first-seen insertion order across the input dictionaries.
 """
 
 from __future__ import annotations
@@ -291,6 +293,8 @@ def dict_zip_longest(*dictionaries, fillvalue=None):  # type: ignore[no-untyped-
     The keys are the union set of the dictionaries.
     The value is a tuple with one value from each dictionary.
     Missing keys are filled with ``fillvalue`` (default: ``None``).
+    Result keys keep first-seen insertion order across the input
+    dictionaries.
 
     .. note::
         When dictionary values can legitimately be ``None``, the default
@@ -318,6 +322,7 @@ def dict_zip_longest(*dictionaries, fillvalue=None):  # type: ignore[no-untyped-
 
 
 def __all_keys(iterables: Iterable[Iterable[_K]]) -> list[_K]:
+    # ``dict.fromkeys`` preserves first-seen order while removing duplicates.
     return list(dict.fromkeys(chain.from_iterable(iterables)))
 
 


### PR DESCRIPTION
## Summary
- Document the output key ordering contract for `dict_zip` and `dict_zip_longest`.
- Rename the internal common-key set in `dict_zip` so the unordered intermediate is not mistaken for iteration order.

## Verification
- `uv run poe format`
- `uv run poe check`
- `uv run poe test`
- `uv run poe coverage-xml`
- `uv build`
- `git diff --check`
- `check-pr-collateral` (0 violations, 0 advisories)
- implement-validator foreground gate: `overall: pass`

## Notes
`uv build` emits existing setuptools license deprecation warnings, but the build succeeds.
