### PR TITLE
Add zero-argument dict_zip_longest overload

### DIFF
--- a/dict_zip/dict_zip_longest.py
+++ b/dict_zip/dict_zip_longest.py
@@ -26,6 +26,11 @@ _T9 = TypeVar("_T9")
 
 
 @overload
+def dict_zip_longest(
+    *,
+    fillvalue: object | None = None,
+) -> dict[object, tuple[()]]: ...
+@overload
 def dict_zip_longest(dict1: dict[_K, _T1]) -> dict[_K, tuple[_T1 | None]]: ...
 @overload
 def dict_zip_longest(

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -5,6 +5,11 @@ def test_dict_zip_without_dictionaries() -> None:
     assert dict_zip() == {}
 
 
+def test_dict_zip_longest_without_dictionaries() -> None:
+    assert dict_zip_longest() == {}
+    assert dict_zip_longest(fillvalue=10) == {}
+
+
 def test_basis() -> None:
     d1 = {"a": 1, "b": 2, "c": 3}
     d2 = {"a": 4, "b": 5}


### PR DESCRIPTION
## Summary
- Add the missing zero-argument overload for `dict_zip_longest`, including keyword-only `fillvalue`.
- Cover the empty-call runtime behavior for both `dict_zip_longest()` and `dict_zip_longest(fillvalue=...)`.

## Verification
- `uv run ruff format --check dict_zip tests`
- `uv run poe check`
- `uv run poe test`
- `git diff --check`
- collateral check: clean
