### PR TITLE
ci: run Python checks in parallel

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -36,20 +36,21 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Lint
-        run: uv run poe check
+      - parallel:
+          - name: Lint
+            run: uv run poe check
 
-      - name: Check Python version
-        run: |
-          actual_version=$(uv run python --version)
-          expected_version="${{ matrix.python }}"
-          if [[ "$actual_version" != *"$expected_version"* ]]; then
-            echo "Expected $expected_version, but got $actual_version"
-            exit 1
-          fi
+          - name: Check Python version
+            run: |
+              actual_version=$(uv run python --version)
+              expected_version="${{ matrix.python }}"
+              if [[ "$actual_version" != *"$expected_version"* ]]; then
+                echo "Expected $expected_version, but got $actual_version"
+                exit 1
+              fi
 
-      - name: Test
-        run: uv run poe test
+          - name: Test
+            run: uv run poe test
 
       - name: Coverage
         run: uv run poe coverage-xml


### PR DESCRIPTION
## Summary

- Run independent Python validation steps in `.github/workflows/python-test.yml` with GitHub Actions step-level `parallel` execution.
- Keep coverage generation or reporting sequential after the test step completes.

## Validation

- Parsed `.github/workflows/python-test.yml` as YAML.
- Local pre-commit check passed.
- Local `uv run poe test` passed.

## Notes

- Local `actionlint 1.7.12` does not recognize the new `parallel` step syntax yet.
